### PR TITLE
do not pin Go compiler version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sapcc/mutavault
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/hashicorp/vault/api v1.12.0


### PR DESCRIPTION
You probably don't want to have to touch your go.mod for every dot release of the compiler.